### PR TITLE
Update error message for login failure in Spanish

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ export default function LoginPage() {
 
       router.push("/chat");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Error al iniciar sesión");
+      setError("El usuario no existe o las credenciales son invalidas");
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
- Change error message to "El usuario no existe o las credenciales son invalidas" for better clarity on login issues.
- This improves user experience by providing specific feedback on authentication errors.

🤖 Generated with [Claude Code](https://claude.ai/code)